### PR TITLE
node 16 required due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "https://github.com/satchafunkilus/ioBroker.rmb-bhkw"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.4",
     "puppeteer": ">=21.4.1"


### PR DESCRIPTION
Adapter core 3.x.x is known to fail when installed at node 14 or older. So this adapter requires node 16 minimum.